### PR TITLE
22 del terminal

### DIFF
--- a/py-builder/repos/assets/text_dat.py
+++ b/py-builder/repos/assets/text_dat.py
@@ -29,7 +29,8 @@ async def get_text_dat():
             "/permission view  ":"/permission view <user> で、userのbot操作権利を表示します。",
             "/lang             ":"/lang <lang> で、botの言語を変更します。",
             "/tokengen         ":"/tokengen で、webでログインするためのトークンを生成します。",
-            "/terminal         ":"/terminal で、サーバーのコンソールを実行したチャンネルに紐づけます。",
+            "/terminal set     ":"/terminal set <ch> で、サーバーのコンソールを実行したチャンネルに紐づけます。chが省略された場合は現在のチャンネルに紐づけます。",
+            "/terminal del     ":"/terminal del で、サーバーのコンソールを実行したチャンネルを解除します。",
             "/announce         ":"/announce embed <file | text> で、サーバーにmimd形式のメッセージを送信します。タイトルを|title|に続けて設定し、以後\\nで改行を行い内容を記述してください。",
         },
         "en":{
@@ -47,7 +48,8 @@ async def get_text_dat():
             "/permission view  ":"/permission view <user> displays the user's bot operation rights.",
             "/lang             ":"/lang <lang> changes the bot's language.",
             "/tokengen         ":"/tokengen generates a token for login to the web.",
-            "/terminal         ":"/terminal connects the server's console to a channel.",
+            "/terminal set     ":"/terminal set <ch> connects the server's console to a channel. If ch is omitted, the current channel is connected.",
+            "/terminal del     ":"/terminal del disconnects the server's console from a channel.",
             "/announce         ":"/announce embed <file | text> sends an embed message to the server. Set the title after |title| and enter the content after \\n.",
         },
     }
@@ -86,7 +88,10 @@ async def get_text_dat():
             },
             "lang":"botの言語を変更します。引数には言語コードを指定します。",
             "tokengen":"webにログインするためのトークンを生成します。",
-            "terminal":"サーバーのコンソールを実行したチャンネルに紐づけます。",
+            "terminal":{
+                "set":"サーバーのコンソールを実行したチャンネルに紐づけます。",
+                "del":"コンソール紐づけを実行したチャンネルから解除します。",
+            },
             "update":"botを更新します。非推奨となった/replaceの後継コマンドです。",
             "announce":{
                 "embed":"discordにテキストをembedで送信します。引数にはmd形式のテキストファイルを指定するか、文字列を指定します。",
@@ -124,7 +129,10 @@ async def get_text_dat():
             },
             "lang":"Change the bot's language. With an argument, specify the language code.",
             "tokengen":"Generate a token for login to the web.",
-            "terminal":"Connect the server's console to a channel.",
+            "terminal":{
+                "set":"Connect the server's console to a channel.",
+                "del":"Disconnect the server's console from a channel.",
+            },
             "update":"Update the bot. This is a successor command of /replace.",
             "announce":{
                 "embed":"Send text to discord with embed. Specify a md-formatted text file or a string as an argument.",
@@ -249,7 +257,7 @@ async def get_text_dat():
                 "success":"生成したトークン(30日間有効) : {}",
             },
             "terminal":{
-                "success":"サーバーのコンソールを{}に紐づけました",
+                "success":"サーバーのコンソールを{}に設定しました。",
             },
             "update":{
                 "same":"存在するファイルは既に最新です",

--- a/py-builder/repos/assets/text_dat.py
+++ b/py-builder/repos/assets/text_dat.py
@@ -215,10 +215,11 @@ async def get_text_dat():
                 "success":"ファイルコピーが完了しました！",
                 "create":{
                     "data_not_found":"データが見つかりません",
-                    "path_not_allowed":"不正なパス",
+                    "path_not_allowed":"許可されないパス",
                 },
                 "apply":{
                     "path_not_found":"指定されたパスが見つかりません",
+                    "path_not_allowed":"許可されないパス",
                 },
             },
             "replace":{
@@ -358,6 +359,7 @@ async def get_text_dat():
                 },
                 "apply":{
                     "path_not_found":"Path is not exists",
+                    "path_not_allowed":"Path not allowed",
                 },
             },
             "replace":{

--- a/py-builder/repos/assets/utils.py
+++ b/py-builder/repos/assets/utils.py
@@ -49,8 +49,7 @@ async def reload_config():
 async def rewrite_config(config: dict) -> bool:
     try:
         with open(config_file_place, 'w') as f:
-            import json
-            json.dump(config, f,indent=4)
+            json.dump(config, f,indent=4, ensure_ascii=False)
         return True
     except:
         return False

--- a/py-builder/repos/constant.py
+++ b/py-builder/repos/constant.py
@@ -82,7 +82,8 @@ COMMAND_PERMISSION = {
     "permission change":4,
     "lang":2,
     "tokengen":1,
-    "terminal":1,
+    "terminal set":1,
+    "terminal del":1,
     "update":3,
     "announce embed":4,
 }

--- a/py-builder/repos/discord/command/_header.py
+++ b/py-builder/repos/discord/command/_header.py
@@ -280,26 +280,10 @@ async def tokengen(interaction: discord.Interaction):
         json.dump(item,f,indent=4,ensure_ascii=False)
     token_logger.info('token added : ' + str(dat_token))
 
-#/terminal
-@tree.command(name="terminal",description=COMMAND_DESCRIPTION[lang]["terminal"])
-async def terminal(interaction: discord.Interaction):
-    global where_terminal
-    await print_user(terminal_logger,interaction.user)
-    embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal")
-    # 権限レベルが足りていないなら
-    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
-        await not_enough_permission(interaction,terminal_logger)
-        return
-    #発言したチャンネルをwhere_terminalに登録
-    where_terminal = interaction.channel_id
-    config["discord_commands"]["terminal"]["discord"] = where_terminal
-    terminal_logger.info(f"terminal setting -> {where_terminal}")
-    #configを書き換え
-    with open(now_path + "/.config","w") as f:
-        json.dump(config,f,indent=4,ensure_ascii=False)
-    embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
-    await interaction.response.send_message(embed=embed)
-
+#!open ./repos/discord/command/terminal/common.py
+#!ignore
+from terminal.common import *
+#!end-ignore
 
 #/help
 @tree.command(name="help",description=COMMAND_DESCRIPTION[lang]["help"])

--- a/py-builder/repos/discord/command/backup/apply.py
+++ b/py-builder/repos/discord/command/backup/apply.py
@@ -3,6 +3,7 @@ from ....logger.logger_create import *
 from ....minecraft.read_properties import *
 from ....assets.text_dat import *
 from ....assets.utils import *
+from ..cmd.stdin.common import *
 from .common import *
 #!end-ignore
 
@@ -38,6 +39,12 @@ async def backup_apply(interaction:discord.Interaction, witch:str, path:str = ""
     if not os.path.exists(os.path.join(server_path,path)):
         backup_apply_logger.error('data not found : ' + os.path.join(server_path,path))
         embed.add_field(name="",value = RESPONSE_MSG["backup"]["apply"]["path_not_found"] + ":" + os.path.join(server_path,path),inline=False)
+        await interaction.response.send_message(embed=embed)
+        return
+    # 操作可能パスかを判定
+    if not is_path_within_scope(os.path.join(server_path,path)) or await is_important_bot_file(os.path.join(server_path,path)):
+        backup_logger.error("path not allowed : " + os.path.join(server_path,path))
+        embed.add_field(name="",value = RESPONSE_MSG["backup"]["apply"]["path_not_allowed"] + ":" + os.path.join(server_path,path),inline=False)
         await interaction.response.send_message(embed=embed)
         return
     backup_apply_logger.info('backup apply started' + " -> " + witch + " to " + os.path.join(server_path,path,witch))

--- a/py-builder/repos/discord/command/backup/create.py
+++ b/py-builder/repos/discord/command/backup/create.py
@@ -3,6 +3,8 @@ from ....logger.logger_create import *
 from ....minecraft.read_properties import *
 from ....assets.text_dat import *
 from ....assets.utils import *
+from ....constant import *
+from ..cmd.stdin.common import *
 from .common import *
 #!end-ignore
 
@@ -15,7 +17,7 @@ async def backup(interaction: discord.Interaction,path:str = "worlds"):
     world_name = path
     await print_user(backup_logger,interaction.user)
     global exist_files, copyed_files
-    embed = ModifiedEmbeds.DefaultEmbed(title= f"/backup {world_name}")
+    embed = ModifiedEmbeds.DefaultEmbed(title= f"/backup create {world_name}")
     #管理者権限を要求
     if await user_permission(interaction.user) < COMMAND_PERMISSION["backup create"]:
         await not_enough_permission(interaction,backup_logger) 
@@ -26,7 +28,7 @@ async def backup(interaction: discord.Interaction,path:str = "worlds"):
         await interaction.response.send_message(embed=embed)
         return
     # 操作可能パスかを判定
-    if not is_path_within_scope(from_backup):
+    if not is_path_within_scope(from_backup) or await is_important_bot_file(from_backup):
         backup_logger.error("path not allowed : " + from_backup)
         embed.add_field(name="",value = RESPONSE_MSG["backup"]["create"]["path_not_allowed"] + ":" + from_backup,inline=False)
         await interaction.response.send_message(embed=embed)

--- a/py-builder/repos/discord/command/terminal/common.py
+++ b/py-builder/repos/discord/command/terminal/common.py
@@ -9,15 +9,13 @@ from ....assets.utils import *
 
 command_group_terminal = app_commands.Group(name="terminal",description="terminal group")
 
-async def change_terminal_ch(channel: int | bool):    
+async def change_terminal_ch(channel: int | bool, logger: logging.Logger):    
     global where_terminal
     #terminalを無効化
     where_terminal = channel
     config["discord_commands"]["terminal"]["discord"] = where_terminal
-    terminal_logger.info(f"terminal setting -> {where_terminal}")
-    #configを書き換え
-    with open(now_path + "/.config","w") as f:
-        json.dump(config,f,indent=4,ensure_ascii=False)
+    logger.info(f"terminal setting -> {where_terminal}")
+    await rewrite_config(config=config)
 
 #!open ./repos/discord/command/terminal/set.py
 #!ignore

--- a/py-builder/repos/discord/command/terminal/common.py
+++ b/py-builder/repos/discord/command/terminal/common.py
@@ -7,6 +7,17 @@ from ....assets.text_dat import *
 from ....assets.utils import *
 #!end-ignore
 
+command_group_terminal = app_commands.Group(name="terminal",description="terminal group")
+
+async def change_terminal_ch(channel: int | False):    
+    #terminalを無効化
+    where_terminal = channel
+    config["discord_commands"]["terminal"]["discord"] = where_terminal
+    terminal_logger.info(f"terminal setting -> {where_terminal}")
+    #configを書き換え
+    with open(now_path + "/.config","w") as f:
+        json.dump(config,f,indent=4,ensure_ascii=False)
+
 #!open ./repos/discord/command/terminal/set.py
 #!ignore
 from .set import *
@@ -16,3 +27,4 @@ from .set import *
 from .delete import *
 #!end-ignore
 
+tree.add_command(command_group_terminal)

--- a/py-builder/repos/discord/command/terminal/common.py
+++ b/py-builder/repos/discord/command/terminal/common.py
@@ -1,0 +1,18 @@
+#!ignore
+from ....imports import *
+from ....constant import *
+from ....logger.logger_create import *
+from ....minecraft.read_properties import *
+from ....assets.text_dat import *
+from ....assets.utils import *
+#!end-ignore
+
+#!open ./repos/discord/command/terminal/set.py
+#!ignore
+from .set import *
+#!end-ignore
+#!open ./repos/discord/command/terminal/delete.py
+#!ignore
+from .delete import *
+#!end-ignore
+

--- a/py-builder/repos/discord/command/terminal/common.py
+++ b/py-builder/repos/discord/command/terminal/common.py
@@ -9,7 +9,8 @@ from ....assets.utils import *
 
 command_group_terminal = app_commands.Group(name="terminal",description="terminal group")
 
-async def change_terminal_ch(channel: int | False):    
+async def change_terminal_ch(channel: int | bool):    
+    global where_terminal
     #terminalを無効化
     where_terminal = channel
     config["discord_commands"]["terminal"]["discord"] = where_terminal

--- a/py-builder/repos/discord/command/terminal/delete.py
+++ b/py-builder/repos/discord/command/terminal/delete.py
@@ -17,7 +17,7 @@ async def terminal_set(interaction: discord.Interaction):
     await print_user(terminal_delete_logger,interaction.user)
     embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal del")
     # 権限レベルが足りていないなら
-    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
+    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal del"]:
         await not_enough_permission(interaction,terminal_delete_logger)
         return
     #発言したチャンネルをwhere_terminalに登録

--- a/py-builder/repos/discord/command/terminal/delete.py
+++ b/py-builder/repos/discord/command/terminal/delete.py
@@ -1,0 +1,26 @@
+#!ignore
+from ....imports import *
+from ....constant import *
+from ....logger.logger_create import *
+from ....minecraft.read_properties import *
+from ....assets.text_dat import *
+from ....assets.utils import *
+from .common import *
+#!end-ignore
+
+terminal_delete_logger = terminal_logger.getChild("delete")
+
+#/terminal
+@command_group_terminal.command(name="del",description=COMMAND_DESCRIPTION[lang]["terminal"])
+async def terminal_set(interaction: discord.Interaction):
+    global where_terminal
+    await print_user(terminal_logger,interaction.user)
+    embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal del")
+    # 権限レベルが足りていないなら
+    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
+        await not_enough_permission(interaction,terminal_logger)
+        return
+    #発言したチャンネルをwhere_terminalに登録
+    change_terminal_ch(False)
+    embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
+    await interaction.response.send_message(embed=embed)

--- a/py-builder/repos/discord/command/terminal/delete.py
+++ b/py-builder/repos/discord/command/terminal/delete.py
@@ -11,7 +11,7 @@ from .common import *
 terminal_delete_logger = terminal_logger.getChild("delete")
 
 #/terminal
-@command_group_terminal.command(name="del",description=COMMAND_DESCRIPTION[lang]["terminal"])
+@command_group_terminal.command(name="del",description=COMMAND_DESCRIPTION[lang]["terminal"]["set"])
 async def terminal_set(interaction: discord.Interaction):
     global where_terminal
     await print_user(terminal_delete_logger,interaction.user)
@@ -21,6 +21,6 @@ async def terminal_set(interaction: discord.Interaction):
         await not_enough_permission(interaction,terminal_delete_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
-    await change_terminal_ch(False)
+    await change_terminal_ch(False, terminal_delete_logger)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)

--- a/py-builder/repos/discord/command/terminal/delete.py
+++ b/py-builder/repos/discord/command/terminal/delete.py
@@ -21,6 +21,6 @@ async def terminal_set(interaction: discord.Interaction):
         await not_enough_permission(interaction,terminal_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
-    change_terminal_ch(False)
+    await change_terminal_ch(False)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)

--- a/py-builder/repos/discord/command/terminal/delete.py
+++ b/py-builder/repos/discord/command/terminal/delete.py
@@ -14,11 +14,11 @@ terminal_delete_logger = terminal_logger.getChild("delete")
 @command_group_terminal.command(name="del",description=COMMAND_DESCRIPTION[lang]["terminal"])
 async def terminal_set(interaction: discord.Interaction):
     global where_terminal
-    await print_user(terminal_logger,interaction.user)
+    await print_user(terminal_delete_logger,interaction.user)
     embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal del")
     # 権限レベルが足りていないなら
     if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
-        await not_enough_permission(interaction,terminal_logger)
+        await not_enough_permission(interaction,terminal_delete_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
     await change_terminal_ch(False)

--- a/py-builder/repos/discord/command/terminal/set.py
+++ b/py-builder/repos/discord/command/terminal/set.py
@@ -17,7 +17,7 @@ async def terminal_set(interaction: discord.Interaction, channel:discord.TextCha
     await print_user(terminal_set_logger,interaction.user)
     embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal set {channel}")
     # 権限レベルが足りていないなら
-    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
+    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal set"]:
         await not_enough_permission(interaction,terminal_set_logger)
         return
     #発言したチャンネルをwhere_terminalに登録

--- a/py-builder/repos/discord/command/terminal/set.py
+++ b/py-builder/repos/discord/command/terminal/set.py
@@ -8,24 +8,19 @@ from ....assets.utils import *
 from .common import *
 #!end-ignore
 
-
+terminal_set_logger = terminal_logger.getChild("set")
 
 #/terminal
-@tree.command(name="terminal",description=COMMAND_DESCRIPTION[lang]["terminal"])
-async def terminal(interaction: discord.Interaction):
+@command_group_terminal.command(name="set",description=COMMAND_DESCRIPTION[lang]["terminal"])
+async def terminal_set(interaction: discord.Interaction, channel:discord.TextChannel = None):
     global where_terminal
     await print_user(terminal_logger,interaction.user)
-    embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal")
+    embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal set {channel}")
     # 権限レベルが足りていないなら
     if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
         await not_enough_permission(interaction,terminal_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
-    where_terminal = interaction.channel_id
-    config["discord_commands"]["terminal"]["discord"] = where_terminal
-    terminal_logger.info(f"terminal setting -> {where_terminal}")
-    #configを書き換え
-    with open(now_path + "/.config","w") as f:
-        json.dump(config,f,indent=4,ensure_ascii=False)
+    change_terminal_ch(channel.id)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)

--- a/py-builder/repos/discord/command/terminal/set.py
+++ b/py-builder/repos/discord/command/terminal/set.py
@@ -11,7 +11,7 @@ from .common import *
 terminal_set_logger = terminal_logger.getChild("set")
 
 #/terminal
-@command_group_terminal.command(name="set",description=COMMAND_DESCRIPTION[lang]["terminal"])
+@command_group_terminal.command(name="set",description=COMMAND_DESCRIPTION[lang]["terminal"]["del"])
 async def terminal_set(interaction: discord.Interaction, channel:discord.TextChannel = None):
     global where_terminal
     await print_user(terminal_set_logger,interaction.user)
@@ -21,6 +21,6 @@ async def terminal_set(interaction: discord.Interaction, channel:discord.TextCha
         await not_enough_permission(interaction,terminal_set_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
-    await change_terminal_ch(channel.id)
+    await change_terminal_ch(channel.id if channel else interaction.channel.id, terminal_set_logger)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)

--- a/py-builder/repos/discord/command/terminal/set.py
+++ b/py-builder/repos/discord/command/terminal/set.py
@@ -14,11 +14,11 @@ terminal_set_logger = terminal_logger.getChild("set")
 @command_group_terminal.command(name="set",description=COMMAND_DESCRIPTION[lang]["terminal"])
 async def terminal_set(interaction: discord.Interaction, channel:discord.TextChannel = None):
     global where_terminal
-    await print_user(terminal_logger,interaction.user)
+    await print_user(terminal_set_logger,interaction.user)
     embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal set {channel}")
     # 権限レベルが足りていないなら
     if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
-        await not_enough_permission(interaction,terminal_logger)
+        await not_enough_permission(interaction,terminal_set_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
     await change_terminal_ch(channel.id)

--- a/py-builder/repos/discord/command/terminal/set.py
+++ b/py-builder/repos/discord/command/terminal/set.py
@@ -1,0 +1,31 @@
+#!ignore
+from ....imports import *
+from ....constant import *
+from ....logger.logger_create import *
+from ....minecraft.read_properties import *
+from ....assets.text_dat import *
+from ....assets.utils import *
+from .common import *
+#!end-ignore
+
+
+
+#/terminal
+@tree.command(name="terminal",description=COMMAND_DESCRIPTION[lang]["terminal"])
+async def terminal(interaction: discord.Interaction):
+    global where_terminal
+    await print_user(terminal_logger,interaction.user)
+    embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal")
+    # 権限レベルが足りていないなら
+    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
+        await not_enough_permission(interaction,terminal_logger)
+        return
+    #発言したチャンネルをwhere_terminalに登録
+    where_terminal = interaction.channel_id
+    config["discord_commands"]["terminal"]["discord"] = where_terminal
+    terminal_logger.info(f"terminal setting -> {where_terminal}")
+    #configを書き換え
+    with open(now_path + "/.config","w") as f:
+        json.dump(config,f,indent=4,ensure_ascii=False)
+    embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
+    await interaction.response.send_message(embed=embed)

--- a/py-builder/repos/discord/command/terminal/set.py
+++ b/py-builder/repos/discord/command/terminal/set.py
@@ -21,6 +21,6 @@ async def terminal_set(interaction: discord.Interaction, channel:discord.TextCha
         await not_enough_permission(interaction,terminal_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
-    change_terminal_ch(channel.id)
+    await change_terminal_ch(channel.id)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)

--- a/server.py
+++ b/server.py
@@ -1171,10 +1171,11 @@ async def get_text_dat():
                 "success":"ファイルコピーが完了しました！",
                 "create":{
                     "data_not_found":"データが見つかりません",
-                    "path_not_allowed":"不正なパス",
+                    "path_not_allowed":"許可されないパス",
                 },
                 "apply":{
                     "path_not_found":"指定されたパスが見つかりません",
+                    "path_not_allowed":"許可されないパス",
                 },
             },
             "replace":{
@@ -1314,6 +1315,7 @@ async def get_text_dat():
                 },
                 "apply":{
                     "path_not_found":"Path is not exists",
+                    "path_not_allowed":"Path not allowed",
                 },
             },
             "replace":{
@@ -2571,7 +2573,7 @@ async def backup(interaction: discord.Interaction,path:str = "worlds"):
     world_name = path
     await print_user(backup_logger,interaction.user)
     global exist_files, copyed_files
-    embed = ModifiedEmbeds.DefaultEmbed(title= f"/backup {world_name}")
+    embed = ModifiedEmbeds.DefaultEmbed(title= f"/backup create {world_name}")
     #管理者権限を要求
     if await user_permission(interaction.user) < COMMAND_PERMISSION["backup create"]:
         await not_enough_permission(interaction,backup_logger) 
@@ -2582,7 +2584,7 @@ async def backup(interaction: discord.Interaction,path:str = "worlds"):
         await interaction.response.send_message(embed=embed)
         return
     # 操作可能パスかを判定
-    if not is_path_within_scope(from_backup):
+    if not is_path_within_scope(from_backup) or await is_important_bot_file(from_backup):
         backup_logger.error("path not allowed : " + from_backup)
         embed.add_field(name="",value = RESPONSE_MSG["backup"]["create"]["path_not_allowed"] + ":" + from_backup,inline=False)
         await interaction.response.send_message(embed=embed)
@@ -2636,6 +2638,12 @@ async def backup_apply(interaction:discord.Interaction, witch:str, path:str = ""
     if not os.path.exists(os.path.join(server_path,path)):
         backup_apply_logger.error('data not found : ' + os.path.join(server_path,path))
         embed.add_field(name="",value = RESPONSE_MSG["backup"]["apply"]["path_not_found"] + ":" + os.path.join(server_path,path),inline=False)
+        await interaction.response.send_message(embed=embed)
+        return
+    # 操作可能パスかを判定
+    if not is_path_within_scope(os.path.join(server_path,path)) or await is_important_bot_file(os.path.join(server_path,path)):
+        backup_logger.error("path not allowed : " + os.path.join(server_path,path))
+        embed.add_field(name="",value = RESPONSE_MSG["backup"]["apply"]["path_not_allowed"] + ":" + os.path.join(server_path,path),inline=False)
         await interaction.response.send_message(embed=embed)
         return
     backup_apply_logger.info('backup apply started' + " -> " + witch + " to " + os.path.join(server_path,path,witch))

--- a/server.py
+++ b/server.py
@@ -2936,7 +2936,7 @@ async def terminal_set(interaction: discord.Interaction, channel:discord.TextCha
         await not_enough_permission(interaction,terminal_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
-    change_terminal_ch(channel.id)
+    await change_terminal_ch(channel.id)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)
 #--------------------
@@ -2958,7 +2958,7 @@ async def terminal_set(interaction: discord.Interaction):
         await not_enough_permission(interaction,terminal_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
-    change_terminal_ch(False)
+    await change_terminal_ch(False)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)
 

--- a/server.py
+++ b/server.py
@@ -2909,7 +2909,8 @@ async def tokengen(interaction: discord.Interaction):
 
 command_group_terminal = app_commands.Group(name="terminal",description="terminal group")
 
-async def change_terminal_ch(channel: int | False):    
+async def change_terminal_ch(channel: int | bool):    
+    global where_terminal
     #terminalを無効化
     where_terminal = channel
     config["discord_commands"]["terminal"]["discord"] = where_terminal

--- a/server.py
+++ b/server.py
@@ -2903,25 +2903,70 @@ async def tokengen(interaction: discord.Interaction):
         json.dump(item,f,indent=4,ensure_ascii=False)
     token_logger.info('token added : ' + str(dat_token))
 
-#/terminal
-@tree.command(name="terminal",description=COMMAND_DESCRIPTION[lang]["terminal"])
-async def terminal(interaction: discord.Interaction):
-    global where_terminal
-    await print_user(terminal_logger,interaction.user)
-    embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal")
-    # 権限レベルが足りていないなら
-    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
-        await not_enough_permission(interaction,terminal_logger)
-        return
-    #発言したチャンネルをwhere_terminalに登録
-    where_terminal = interaction.channel_id
+
+#--------------------
+
+
+command_group_terminal = app_commands.Group(name="terminal",description="terminal group")
+
+async def change_terminal_ch(channel: int | False):    
+    #terminalを無効化
+    where_terminal = channel
     config["discord_commands"]["terminal"]["discord"] = where_terminal
     terminal_logger.info(f"terminal setting -> {where_terminal}")
     #configを書き換え
     with open(now_path + "/.config","w") as f:
         json.dump(config,f,indent=4,ensure_ascii=False)
+
+
+#--------------------
+
+
+terminal_set_logger = terminal_logger.getChild("set")
+
+#/terminal
+@command_group_terminal.command(name="set",description=COMMAND_DESCRIPTION[lang]["terminal"])
+async def terminal_set(interaction: discord.Interaction, channel:discord.TextChannel = None):
+    global where_terminal
+    await print_user(terminal_logger,interaction.user)
+    embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal set {channel}")
+    # 権限レベルが足りていないなら
+    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
+        await not_enough_permission(interaction,terminal_logger)
+        return
+    #発言したチャンネルをwhere_terminalに登録
+    change_terminal_ch(channel.id)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)
+#--------------------
+
+
+#--------------------
+
+
+terminal_delete_logger = terminal_logger.getChild("delete")
+
+#/terminal
+@command_group_terminal.command(name="del",description=COMMAND_DESCRIPTION[lang]["terminal"])
+async def terminal_set(interaction: discord.Interaction):
+    global where_terminal
+    await print_user(terminal_logger,interaction.user)
+    embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal del")
+    # 権限レベルが足りていないなら
+    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
+        await not_enough_permission(interaction,terminal_logger)
+        return
+    #発言したチャンネルをwhere_terminalに登録
+    change_terminal_ch(False)
+    embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
+    await interaction.response.send_message(embed=embed)
+
+#--------------------
+
+
+tree.add_command(command_group_terminal)
+
+#--------------------
 
 
 #/help

--- a/server.py
+++ b/server.py
@@ -984,7 +984,8 @@ async def get_text_dat():
             "/permission view  ":"/permission view <user> で、userのbot操作権利を表示します。",
             "/lang             ":"/lang <lang> で、botの言語を変更します。",
             "/tokengen         ":"/tokengen で、webでログインするためのトークンを生成します。",
-            "/terminal         ":"/terminal で、サーバーのコンソールを実行したチャンネルに紐づけます。",
+            "/terminal set     ":"/terminal set <ch> で、サーバーのコンソールを実行したチャンネルに紐づけます。chが省略された場合は現在のチャンネルに紐づけます。",
+            "/terminal del     ":"/terminal del で、サーバーのコンソールを実行したチャンネルを解除します。",
             "/announce         ":"/announce embed <file | text> で、サーバーにmimd形式のメッセージを送信します。タイトルを|title|に続けて設定し、以後\\nで改行を行い内容を記述してください。",
         },
         "en":{
@@ -1002,7 +1003,8 @@ async def get_text_dat():
             "/permission view  ":"/permission view <user> displays the user's bot operation rights.",
             "/lang             ":"/lang <lang> changes the bot's language.",
             "/tokengen         ":"/tokengen generates a token for login to the web.",
-            "/terminal         ":"/terminal connects the server's console to a channel.",
+            "/terminal set     ":"/terminal set <ch> connects the server's console to a channel. If ch is omitted, the current channel is connected.",
+            "/terminal del     ":"/terminal del disconnects the server's console from a channel.",
             "/announce         ":"/announce embed <file | text> sends an embed message to the server. Set the title after |title| and enter the content after \\n.",
         },
     }
@@ -1041,7 +1043,10 @@ async def get_text_dat():
             },
             "lang":"botの言語を変更します。引数には言語コードを指定します。",
             "tokengen":"webにログインするためのトークンを生成します。",
-            "terminal":"サーバーのコンソールを実行したチャンネルに紐づけます。",
+            "terminal":{
+                "set":"サーバーのコンソールを実行したチャンネルに紐づけます。",
+                "del":"コンソール紐づけを実行したチャンネルから解除します。",
+            },
             "update":"botを更新します。非推奨となった/replaceの後継コマンドです。",
             "announce":{
                 "embed":"discordにテキストをembedで送信します。引数にはmd形式のテキストファイルを指定するか、文字列を指定します。",
@@ -1079,7 +1084,10 @@ async def get_text_dat():
             },
             "lang":"Change the bot's language. With an argument, specify the language code.",
             "tokengen":"Generate a token for login to the web.",
-            "terminal":"Connect the server's console to a channel.",
+            "terminal":{
+                "set":"Connect the server's console to a channel.",
+                "del":"Disconnect the server's console from a channel.",
+            },
             "update":"Update the bot. This is a successor command of /replace.",
             "announce":{
                 "embed":"Send text to discord with embed. Specify a md-formatted text file or a string as an argument.",
@@ -1204,7 +1212,7 @@ async def get_text_dat():
                 "success":"生成したトークン(30日間有効) : {}",
             },
             "terminal":{
-                "success":"サーバーのコンソールを{}に紐づけました",
+                "success":"サーバーのコンソールを{}に設定しました。",
             },
             "update":{
                 "same":"存在するファイルは既に最新です",
@@ -1434,8 +1442,7 @@ async def reload_config():
 async def rewrite_config(config: dict) -> bool:
     try:
         with open(config_file_place, 'w') as f:
-            import json
-            json.dump(config, f,indent=4)
+            json.dump(config, f,indent=4, ensure_ascii=False)
         return True
     except:
         return False
@@ -2909,15 +2916,13 @@ async def tokengen(interaction: discord.Interaction):
 
 command_group_terminal = app_commands.Group(name="terminal",description="terminal group")
 
-async def change_terminal_ch(channel: int | bool):    
+async def change_terminal_ch(channel: int | bool, logger: logging.Logger):    
     global where_terminal
     #terminalを無効化
     where_terminal = channel
     config["discord_commands"]["terminal"]["discord"] = where_terminal
-    terminal_logger.info(f"terminal setting -> {where_terminal}")
-    #configを書き換え
-    with open(now_path + "/.config","w") as f:
-        json.dump(config,f,indent=4,ensure_ascii=False)
+    logger.info(f"terminal setting -> {where_terminal}")
+    await rewrite_config(config=config)
 
 
 #--------------------
@@ -2926,17 +2931,17 @@ async def change_terminal_ch(channel: int | bool):
 terminal_set_logger = terminal_logger.getChild("set")
 
 #/terminal
-@command_group_terminal.command(name="set",description=COMMAND_DESCRIPTION[lang]["terminal"])
+@command_group_terminal.command(name="set",description=COMMAND_DESCRIPTION[lang]["terminal"]["del"])
 async def terminal_set(interaction: discord.Interaction, channel:discord.TextChannel = None):
     global where_terminal
-    await print_user(terminal_logger,interaction.user)
+    await print_user(terminal_set_logger,interaction.user)
     embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal set {channel}")
     # 権限レベルが足りていないなら
     if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
-        await not_enough_permission(interaction,terminal_logger)
+        await not_enough_permission(interaction,terminal_set_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
-    await change_terminal_ch(channel.id)
+    await change_terminal_ch(channel.id if channel else interaction.channel.id, terminal_set_logger)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)
 #--------------------
@@ -2948,17 +2953,17 @@ async def terminal_set(interaction: discord.Interaction, channel:discord.TextCha
 terminal_delete_logger = terminal_logger.getChild("delete")
 
 #/terminal
-@command_group_terminal.command(name="del",description=COMMAND_DESCRIPTION[lang]["terminal"])
+@command_group_terminal.command(name="del",description=COMMAND_DESCRIPTION[lang]["terminal"]["set"])
 async def terminal_set(interaction: discord.Interaction):
     global where_terminal
-    await print_user(terminal_logger,interaction.user)
+    await print_user(terminal_delete_logger,interaction.user)
     embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal del")
     # 権限レベルが足りていないなら
     if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
-        await not_enough_permission(interaction,terminal_logger)
+        await not_enough_permission(interaction,terminal_delete_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
-    await change_terminal_ch(False)
+    await change_terminal_ch(False, terminal_delete_logger)
     embed.add_field(name="",value=RESPONSE_MSG["terminal"]["success"].format(where_terminal),inline=False)
     await interaction.response.send_message(embed=embed)
 

--- a/server.py
+++ b/server.py
@@ -122,7 +122,8 @@ COMMAND_PERMISSION = {
     "permission change":4,
     "lang":2,
     "tokengen":1,
-    "terminal":1,
+    "terminal set":1,
+    "terminal del":1,
     "update":3,
     "announce embed":4,
 }
@@ -2937,7 +2938,7 @@ async def terminal_set(interaction: discord.Interaction, channel:discord.TextCha
     await print_user(terminal_set_logger,interaction.user)
     embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal set {channel}")
     # 権限レベルが足りていないなら
-    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
+    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal set"]:
         await not_enough_permission(interaction,terminal_set_logger)
         return
     #発言したチャンネルをwhere_terminalに登録
@@ -2959,7 +2960,7 @@ async def terminal_set(interaction: discord.Interaction):
     await print_user(terminal_delete_logger,interaction.user)
     embed = ModifiedEmbeds.DefaultEmbed(title= f"/terminal del")
     # 権限レベルが足りていないなら
-    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal"]:
+    if await user_permission(interaction.user) < COMMAND_PERMISSION["terminal del"]:
         await not_enough_permission(interaction,terminal_delete_logger)
         return
     #発言したチャンネルをwhere_terminalに登録


### PR DESCRIPTION
# /terminalの機能追加

## /terminal を /terminal set へ

 - /terminal set <ch>で選択したチャンネルにターミナル機能を付与(chが存在しない場合、現在のチャンネルを選択)
 - 権限レベルは以前と同様に1

## /terminal del の追加

 - terminalチャンネルを解除できるように
 - 権限レベルを1に設定

## その他

 - /backup create においてimportant pathが保存できる問題を修正
 - /backup apply においてimportant pathを操作できる問題を修正